### PR TITLE
[BUGFIX] Gatsby build command throws an error

### DIFF
--- a/env/production.js
+++ b/env/production.js
@@ -1,0 +1,1 @@
+module.exports = {}


### PR DESCRIPTION
### Description
 - Fixed the error `Cannot find module '/home/marco/Hackcovid/rt-app/env/production.js'` thrown while trying to build the project.

![image](https://user-images.githubusercontent.com/25541453/82586747-73d0e800-9b6e-11ea-8cef-275fd7149c8e.png)
