### PR TITLE
Using Open Sans as secondary font-family

### DIFF
--- a/src/styles/typography.scss
+++ b/src/styles/typography.scss
@@ -1,5 +1,7 @@
+@import url('https://fonts.googleapis.com/css2?family=Open+Sans:wght@300;400;600&display=swap');
+
 * {
-  font-family: "Helvetica", sans-serif;
+  font-family: "Helvetica", "Open Sans", sans-serif;
 }
 
 h3 {


### PR DESCRIPTION
| Open Sans | sans-serif |
| - | - |
| ![image](https://user-images.githubusercontent.com/25541453/84207478-d8a1a300-aa87-11ea-894d-9b965a306174.png) | ![image](https://user-images.githubusercontent.com/25541453/84207486-dccdc080-aa87-11ea-9799-0360e8c7237d.png) |
