### PR TITLE
Fix/styles-path

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -31,8 +31,8 @@ module.exports = {
     {
       resolve: `gatsby-plugin-sass`,
       options: {
-        includePaths: [`${__dirname}/src/styles`],
-        data: `@import "${__dirname}/src/styles/internal";`,
+        includePaths: [__dirname + '/src/styles'],
+        data: '@import "./src/styles/internal";',
       },
     },
   ],


### PR DESCRIPTION
Fala Galera, blza?
Eu uso Windows e o meu projeto não estava rodando aqui por conta do SASS.
Eu estava enfrentando um erro no path... A minha solução foi:

![image](https://user-images.githubusercontent.com/41493938/84711278-53f9cd80-af3c-11ea-953b-78b40e5d177c.png)

O que acham sobre?
Basicamente, se eu usar o template string no __dirname, não sei pq ele está dando um caminho errado.
Eu mudei para ./ e deu certo.
E na propriedade includedPaths, eu usei __dirname + /src/styles e o path ficou correto... porém se eu fizer
`${__dirname}/src/styles` não dá certo.

Oq acham sobre?